### PR TITLE
Typo in rider_category_id "seniors"

### DIFF
--- a/rosemead-ca-us/fare_leg_rules.txt
+++ b/rosemead-ca-us/fare_leg_rules.txt
@@ -1,5 +1,5 @@
 leg_group_id,fare_leg_name,network_id,from_area_id,contains_area_id,to_area_id,is_symmetrical,from_timeframe_id,to_timeframe_id,min_distance,max_distance,distance_type,service_id,min_amount,max_amount,fare_product_id,fare_container_id,rider_category_id,eligible_cap_id,amount,currency
 Rosemead,,,,,,,,,,,,,,,,,,,0.5,USD
-Rosemead,,,,,,,,,,,,,,,,,senior,,0,USD
+Rosemead,,,,,,,,,,,,,,,,,seniors,,0,USD
 Rosemead,,,,,,,,,,,,,,,,,disabled,,0,USD
 Rosemead,,,,,,,,,,,,,,,,,children,,0,USD


### PR DESCRIPTION
Fix the inconsistency between `fare_leg_rules.rider_category_id=senior` and `rider_categories.rider_category_id=seniors`.
The inconsistency prevents any data upload in Transit app and compromises up-to-date schedule information to be displayed to the riders.