### PR TITLE
Add manual trigger and merge main into dev in GTFS Rail Nightly Updater workflow

### DIFF
--- a/.github/workflows/gtfs-rail-nightly-updater.yml
+++ b/.github/workflows/gtfs-rail-nightly-updater.yml
@@ -3,6 +3,7 @@ name: 📅 Nightly GTFS Rail Update
 on:
   schedule:
     - cron: '0 1 * * *' # Runs every day at 1 AM
+  workflow_dispatch: # Allows manual trigger
 
 jobs:
   update-gtfs-rail:
@@ -27,3 +28,10 @@ jobs:
           git add lacmta-rail/current/gtfs_rail.zip
           git commit -m "[Auto] 📅 Nightly GTFS Rail Update - $(date)"
           git push origin main
+
+      - name: Merge main into dev
+        run: |
+          git checkout dev
+          git merge main
+          git push origin dev
+        continue-on-error: true


### PR DESCRIPTION
This pull request adds a manual trigger to the GTFS Rail Nightly Updater workflow, allowing for manual updates in addition to the scheduled daily updates. It also includes a step to merge the main branch into the dev branch to ensure that the dev branch stays up to date with the latest changes.