### PR TITLE
Update GTFS Rail workflow with new image and continue-on-error flag

### DIFF
--- a/.github/workflows/gtfs-rail-nightly-updater.yml
+++ b/.github/workflows/gtfs-rail-nightly-updater.yml
@@ -31,6 +31,7 @@ jobs:
           git add lacmta-rail/current/gtfs_rail.zip
           git commit -m "[Auto] 📅 Nightly GTFS Rail Update - $(date)"
           git push origin main
+        continue-on-error: true
 
       - name: Merge main into dev
         run: |

--- a/.github/workflows/gtfs-rail-nightly-updater.yml
+++ b/.github/workflows/gtfs-rail-nightly-updater.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   update-gtfs-rail:
     runs-on: ubuntu-latest
+    container:
+      image: lacmta/geodb-base
+
 
     steps:
       - name: Checkout the repo

--- a/.github/workflows/gtfs-static-updater-current.yml
+++ b/.github/workflows/gtfs-static-updater-current.yml
@@ -10,12 +10,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy-to-current-db:
+  update-gtfs-rail:
     runs-on: ubuntu-latest
-    
     container:
-      image: python:3.8
-
+      image: lacmta/geodb-base
+      
     steps:
       - uses: actions/checkout@v2
         name: Checkout the repo

--- a/.github/workflows/gtfs-static-updater-future.yml
+++ b/.github/workflows/gtfs-static-updater-future.yml
@@ -12,10 +12,9 @@ on:
 jobs:
   deploy-to-current-db:
     runs-on: ubuntu-latest
-
     container:
-      image: python:3.8
-
+      image: lacmta/geodb-base
+      
     steps:
       - uses: actions/checkout@v2
         name: Checkout the repo

--- a/.github/workflows/gtfs-static-updater-no-validator.yml
+++ b/.github/workflows/gtfs-static-updater-no-validator.yml
@@ -9,9 +9,8 @@ on:
 jobs:
   deploy-to-prod-db:
     runs-on: ubuntu-latest
-
     container:
-      image: python:3.8
+      image: lacmta/geodb-base
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
This pull request updates the GTFS Rail workflow to use the `lacmta/geodb-base` image and adds the `continue-on-error` flag to the `update-gtfs-rail` job. This ensures that the workflow will continue even if there are errors during the update process.