### PR TITLE
Refactor stop sequence join in gtfs_static_updater.py

### DIFF
--- a/.github/workflows/gtfs-static-updater-no-validator.yml
+++ b/.github/workflows/gtfs-static-updater-no-validator.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   deploy-to-prod-db:
     runs-on: ubuntu-latest
+    timeout-minutes: 300  # Set timeout to 2 hours
     container:
       image: lacmta/geodb-base
 


### PR DESCRIPTION
This pull request refactors the stop sequence join in the gtfs_static_updater.py file. It replaces the use of the stop_times_df DataFrame with a new DataFrame called max_stop_sequence_df, which groups the stop times by trip_id and calculates the maximum stop_sequence for each trip. The new DataFrame is then used for the join operation with the trips_df DataFrame. This change improves the efficiency and readability of the code.