### PR TITLE
Fix trip shapes processing in gtfs_static_updater.py

### DIFF
--- a/.scripts/gtfs_static_updater.py
+++ b/.scripts/gtfs_static_updater.py
@@ -245,9 +245,9 @@ def update_gtfs_static_files():
     print("Done processing trip list.")
     print("Processing trip shapes...")
     process_start = timeit.default_timer()
-    shape_lines_df = shapes_combined_gdf.groupby(['shape_id', 'agency_id'])['geometry'].apply(lambda x: LineString(x.tolist())).reset_index()
+    trip_shapes_df = shapes_combined_gdf.groupby(['shape_id', 'agency_id'])['geometry'].apply(lambda x: LineString(x.tolist())).reset_index()
     if debug == False:
-        shape_lines_df.to_postgis('trip_shapes', engine, if_exists='replace', index=False, schema=TARGET_SCHEMA)
+        trip_shapes_df.to_postgis('trip_shapes', engine, if_exists='replace', index=False, schema=TARGET_SCHEMA)
     process_end = timeit.default_timer()
     with open('../logs.txt', 'a+') as f:
         human_readable_date = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
This pull request fixes the trip shapes processing in the gtfs_static_updater.py file. The previous code was incorrectly using the variable name "shape_lines_df" instead of "trip_shapes_df" when saving the processed data to the database. This caused the data to be saved with the wrong name, leading to potential issues downstream. This PR corrects the variable name and ensures that the trip shapes are saved correctly as "trip_shapes" in the database.