### PR TITLE
Fix issue with trip_stop_times in gtfs_static_updater.py

### DIFF
--- a/.scripts/gtfs_static_updater.py
+++ b/.scripts/gtfs_static_updater.py
@@ -243,9 +243,6 @@ def update_gtfs_static_files():
         print(human_readable_date+" | " + "trips_list" + " | " + str(total_time_rounded) + " seconds.", file=f)
         print("******************")
     print("Done processing trip list.")
-
-
-
     print("Processing trip stop times...")
 
     # Assuming stop_times_df already contains 'trip_id', 'stop_id', 'stop_sequence', 'stop_name', etc.
@@ -254,7 +251,7 @@ def update_gtfs_static_files():
 
     # Write the DataFrame to a new table in the PostgreSQL database
     if debug == False:
-        stop_times_df.to_postgis('trip_stop_times', engine, if_exists='replace', index=False, schema=TARGET_SCHEMA)
+        stop_times_df.to_sql('trip_stop_times', engine, if_exists='replace', index=True, schema=TARGET_SCHEMA)
     with open('../logs.txt', 'a+') as f:
         process_end = timeit.default_timer()
         human_readable_date = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
This pull request fixes an issue in the gtfs_static_updater.py file where the `to_postgis` method was used instead of the `to_sql` method when writing the `stop_times_df` DataFrame to the 'trip_stop_times' table in the PostgreSQL database. This caused an error and prevented the data from being updated correctly. The fix replaces the incorrect method call with the correct one, ensuring that the data is written to the table successfully.