### PR TITLE
Refactor: Remove Cython

### DIFF
--- a/.scripts/gtfs_static_updater.py
+++ b/.scripts/gtfs_static_updater.py
@@ -1,24 +1,8 @@
-try:
-    import gtfs_static_utils as gtfs_static_utils
-except ModuleNotFoundError:
-    # No Cython module found, compiling now.
-    # This is another method to compile Cython programs from within a snippet
-    from distutils.core import setup
-    from Cython.Build import cythonize
-
-    setup(
-        ext_modules= cythonize("gtfs_static_utils.pyx"),
-        # build_dir= "build",
-        script_args= ['build_ext', "--inplace"]
-    )
-    import gtfs_static_utils as gtfs_static_utils
-
 import sys, argparse
 
 # from calendar import calendar
 import os
-print(os.getcwd())
-print(os.listdir())
+
 # exit()
 
 import pandas as pd
@@ -227,7 +211,7 @@ def update_gtfs_static_files():
             print("******************")
     print("Processing trip list")
     process_start = timeit.default_timer()
-    trips_list_df = gtfs_static_utils.create_list_of_trips(trips_df,stop_times_df)
+    trips_list_df = create_list_of_trips(trips_df,stop_times_df)
     summarized_trips_df = trips_df[["route_id","trip_id","direction_id","service_id","agency_id"]]
     summarized_trips_df['day_type'] = summarized_trips_df['service_id'].map(get_day_type_from_service_id)
     trips_list_df = trips_list_df.merge(summarized_trips_df, on='trip_id').drop_duplicates(subset=['route_id','day_type','direction_id'])


### PR DESCRIPTION
This pull request removes the Cython module from the codebase. The Cython module was previously used for compiling Cython programs, but it is no longer needed. This change simplifies the code and improves maintainability.