### PR TITLE
Fix GTFS static updater workflow to use bash shell

### DIFF
--- a/.github/workflows/gtfs-static-updater-no-validator.yml
+++ b/.github/workflows/gtfs-static-updater-no-validator.yml
@@ -24,3 +24,4 @@ jobs:
       run: |
           cd ./.scripts
           python gtfs_static_updater.py --db_uri "${{secrets.API_DB_URI}}" --db_schema "metro_api"
+      shell: bash

--- a/.scripts/gtfs_static_utils.pyx
+++ b/.scripts/gtfs_static_utils.pyx
@@ -4,18 +4,18 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from shapely.geometry import Point
 
-cpdef combine_dataframes(temp_df_bus,temp_df_rail):
+def combine_dataframes(temp_df_bus,temp_df_rail):
     return pd.concat([temp_df_bus, temp_df_rail])
 
 
-cpdef create_list_of_trips(trips,stop_times):
+def create_list_of_trips(trips,stop_times):
     print('Creating list of trips')
     global trips_list_df
     trips_list_df = stop_times.groupby('trip_id')['stop_sequence'].max().sort_values(ascending=False).reset_index()
     trips_list_df = trips_list_df.merge(stop_times[['trip_id','stop_id','stop_sequence','route_code']], on=['trip_id','stop_sequence'])
     return trips_list_df
 
-cpdef update_dataframe_to_db(combined_temp_df,target_table_name,engine,target_schema):
+def update_dataframe_to_db(combined_temp_df,target_table_name,engine,target_schema):
     print('Updating dataframe to db')
     combined_temp_df.to_sql(target_table_name,engine,index=False,if_exists="replace",schema=target_schema)
 


### PR DESCRIPTION
This pull request fixes the GTFS static updater workflow to use the bash shell instead of the default shell. This change ensures compatibility and improves the reliability of the workflow.